### PR TITLE
Menambahkan fitur navigasi breadcrumb

### DIFF
--- a/themes/bbta3/layouts/partials/breadcrumb.html
+++ b/themes/bbta3/layouts/partials/breadcrumb.html
@@ -1,0 +1,16 @@
+<nav aria-label="breadcrumb">
+  <ol  class="breadcrumb ribbon bg-darker mt-3 mb-4 py-3">
+      {{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
+  </ol>
+</nav>
+
+{{ define "breadcrumbnav" }}
+    {{ if .p1.Parent }}
+        {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  }}
+    {{ else if not .p1.IsHome }}
+        {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
+    {{ end }}
+    <li class="breadcrumb-item {{ if eq .p1 .p2 }}active{{ end }}">
+      <a href="{{ .p1.Permalink }}" class="link-warning text-decoration-none">{{ .p1.Title }}</a>
+    </li>
+{{ end }}

--- a/themes/bbta3/static/css/_breadcrumb.css
+++ b/themes/bbta3/static/css/_breadcrumb.css
@@ -1,0 +1,3 @@
+ol.breadcrumb.ribbon {
+    border-left: 4px solid #ffc107;
+}


### PR DESCRIPTION
Bagian ini dirasakan perlu saat pengguna masuk ke halaman rinci (_single page_). Navigasi mini atau _breadcrumb_ ini memudahkan pengguna untuk pindah ke halaman induk (_parent page_) dalam satu bagian yang sama.